### PR TITLE
Explicit Exports, Centralized Tag Factory, `forms` updates and addressing TODO

### DIFF
--- a/src/ydnatl/__init__.py
+++ b/src/ydnatl/__init__.py
@@ -1,8 +1,147 @@
 from .core.element import HTMLElement
-from .tags.form import *
-from .tags.html import *
-from .tags.layout import *
-from .tags.lists import *
-from .tags.media import *
-from .tags.table import *
-from .tags.text import *
+from .tags.form import (
+    Textarea,
+    Select,
+    Option,
+    Button,
+    Fieldset,
+    Form,
+    Input,
+    Label,
+    Optgroup,
+)
+from .tags.html import (
+    HTML,
+    Head,
+    Body,
+    Title,
+    Meta,
+    Link as HtmlLink,
+    Script,
+    Style,
+    IFrame,
+)
+from .tags.layout import Div, Section, Header, Nav, Footer, HorizontalRule, Main
+from .tags.lists import (
+    UnorderedList,
+    OrderedList,
+    ListItem,
+    Datalist,
+    DescriptionDetails,
+    DescriptionList,
+    DescriptionTerm,
+)
+from .tags.media import Image, Video, Audio, Source, Picture, Figure, Figcaption, Canvas
+from .tags.table import (
+    Table,
+    TableFooter,
+    TableHeaderCell,
+    TableHeader,
+    TableBody,
+    TableDataCell,
+    TableRow,
+)
+from .tags.text import (
+    H1,
+    H2,
+    H3,
+    H4,
+    H5,
+    H6,
+    Paragraph,
+    Blockquote,
+    Pre,
+    Quote,
+    Cite,
+    Em,
+    Italic,
+    Span,
+    Strong,
+    Abbr,
+    Link,
+    Small,
+    Superscript,
+    Subscript,
+    Time,
+    Code,
+)
+
+__all__ = [
+    "HTMLElement",
+    # form
+    "Textarea",
+    "Select",
+    "Option",
+    "Button",
+    "Fieldset",
+    "Form",
+    "Input",
+    "Label",
+    "Optgroup",
+    # html
+    "HTML",
+    "Head",
+    "Body",
+    "Title",
+    "Meta",
+    "HtmlLink",
+    "Script",
+    "Style",
+    "IFrame",
+    # layout
+    "Div",
+    "Section",
+    "Header",
+    "Nav",
+    "Footer",
+    "HorizontalRule",
+    "Main",
+    # lists
+    "UnorderedList",
+    "OrderedList",
+    "ListItem",
+    "Datalist",
+    "DescriptionDetails",
+    "DescriptionList",
+    "DescriptionTerm",
+    # media
+    "Image",
+    "Video",
+    "Audio",
+    "Source",
+    "Picture",
+    "Figure",
+    "Figcaption",
+    "Canvas",
+    # table
+    "Table",
+    "TableFooter",
+    "TableHeaderCell",
+    "TableHeader",
+    "TableBody",
+    "TableDataCell",
+    "TableRow",
+    # text
+    "H1",
+    "H2",
+    "H3",
+    "H4",
+    "H5",
+    "H6",
+    "Paragraph",
+    "Blockquote",
+    "Pre",
+    "Quote",
+    "Cite",
+    "Em",
+    "Italic",
+    "Span",
+    "Strong",
+    "Abbr",
+    "Link",
+    "Small",
+    "Superscript",
+    "Subscript",
+    "Time",
+    "Code",
+]

--- a/src/ydnatl/tags/form.py
+++ b/src/ydnatl/tags/form.py
@@ -1,18 +1,20 @@
 from ydnatl.core.element import HTMLElement
+from ydnatl.tags.tag_factory import simple_tag_class
 
 
-class Textarea(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "textarea"})
+Textarea = simple_tag_class("textarea")
+Select = simple_tag_class("select")
+Option = simple_tag_class("option")
+Button = simple_tag_class("button")
+Fieldset = simple_tag_class("fieldset")
+Input = simple_tag_class("input", self_closing=True)
+Optgroup = simple_tag_class("optgroup")
 
 
-class Select(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "select"})
-
-    @staticmethod
-    def with_items(*items, **kwargs):
-        opt = Select(**kwargs)
+class Select(Select):
+    @classmethod
+    def with_items(cls, *items, **kwargs):
+        opt = cls(**kwargs)
         for item in items:
             if isinstance(item, HTMLElement):
                 opt.append(item)
@@ -21,19 +23,12 @@ class Select(HTMLElement):
         return opt
 
 
-class Option(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "option"})
+def label_extra_init(self, kwargs):
+    if "for_element" in kwargs:
+        kwargs["for"] = kwargs.pop("for_element")
 
 
-class Button(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "button"})
-
-
-class Fieldset(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "fieldset"})
+Label = simple_tag_class("label", extra_init=label_extra_init)
 
 
 class Form(HTMLElement):
@@ -43,23 +38,20 @@ class Form(HTMLElement):
     @staticmethod
     def with_fields(*items, **kwargs):
         form = Form(**kwargs)
+        valid_types = (
+            Input,
+            Textarea,
+            Select,
+            Option,
+            Button,
+            Fieldset,
+            Label,
+            Optgroup,
+        )
         for item in items:
-            form.append(item)  # TODO: Check if item is a valid field class
+            if not isinstance(item, valid_types):
+                raise TypeError(
+                    f"Invalid form field: {item!r} (type {type(item).__name__})"
+                )
+            form.append(item)
         return form
-
-
-class Input(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "input", "self_closing": True})
-
-
-class Label(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        if 'for_element' in kwargs:
-            kwargs['for'] = kwargs.pop('for_element')
-        super().__init__(*args, **{**kwargs, "tag": "label"})
-        
-        
-class Optgroup(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "optgroup"})

--- a/src/ydnatl/tags/html.py
+++ b/src/ydnatl/tags/html.py
@@ -1,4 +1,5 @@
 from ydnatl.core.element import HTMLElement
+from ydnatl.tags.tag_factory import simple_tag_class
 
 
 class HTML(HTMLElement):
@@ -8,47 +9,17 @@ class HTML(HTMLElement):
             **{
                 **kwargs | {"lang": "en", "dir": "ltr"},
                 "tag": "html",
-                "self_closing": False
+                "self_closing": False,
             },
         )
         self._prefix = "<!DOCTYPE html>"
 
 
-class Head(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "head"})
-
-
-class Body(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "body"})
-
-
-class Title(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "title"})
-
-
-class Meta(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "meta", "self_closing": True})
-
-
-class Link(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "link", "self_closing": True})
-
-
-class Script(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "script"})
-
-
-class Style(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "style"})
-
-
-class IFrame(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "iframe"})
+Head = simple_tag_class("head")
+Body = simple_tag_class("body")
+Title = simple_tag_class("title")
+Meta = simple_tag_class("meta", self_closing=True)
+Link = simple_tag_class("link", self_closing=True)
+Script = simple_tag_class("script")
+Style = simple_tag_class("style")
+IFrame = simple_tag_class("iframe")

--- a/src/ydnatl/tags/layout.py
+++ b/src/ydnatl/tags/layout.py
@@ -1,36 +1,10 @@
-from ydnatl.core.element import HTMLElement
+from ydnatl.tags.tag_factory import simple_tag_class
 
 
-class Div(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "div"})
-
-
-class Section(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "section"})
-
-
-class Header(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "header"})
-
-
-class Nav(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "nav"})
-
-
-class Footer(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "footer"})
-
-
-class HorizontalRule(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "hr", "self_closing": True})
-
-
-class Main(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "main"})
+Div = simple_tag_class("div")
+Section = simple_tag_class("section")
+Header = simple_tag_class("header")
+Nav = simple_tag_class("nav")
+Footer = simple_tag_class("footer")
+HorizontalRule = simple_tag_class("hr", self_closing=True)
+Main = simple_tag_class("main")

--- a/src/ydnatl/tags/lists.py
+++ b/src/ydnatl/tags/lists.py
@@ -1,4 +1,14 @@
 from ydnatl.core.element import HTMLElement
+from ydnatl.tags.tag_factory import simple_tag_class
+
+
+UnorderedList = simple_tag_class("ul")
+OrderedList = simple_tag_class("ol")
+ListItem = simple_tag_class("li")
+Datalist = simple_tag_class("datalist")
+DescriptionDetails = simple_tag_class("dd")
+DescriptionList = simple_tag_class("dl")
+DescriptionTerm = simple_tag_class("dt")
 
 
 class UnorderedList(HTMLElement):
@@ -29,28 +39,3 @@ class OrderedList(HTMLElement):
             else:
                 ol.append(ListItem(item))
         return ol
-
-
-class ListItem(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "li"})
-
-
-class Datalist(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "datalist"})
-
-
-class DescriptionDetails(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "dd"})
-
-
-class DescriptionList(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "dl"})
-
-
-class DescriptionTerm(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "dt"})

--- a/src/ydnatl/tags/media.py
+++ b/src/ydnatl/tags/media.py
@@ -1,41 +1,11 @@
-from ydnatl.core.element import HTMLElement
+from ydnatl.tags.tag_factory import simple_tag_class
 
 
-class Image(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "img", "self_closing": True})
-
-
-class Video(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "video"})
-
-
-class Audio(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "audio"})
-
-
-class Source(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "source", "self_closing": True})
-
-
-class Picture(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "picture"})
-
-
-class Figure(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "figure"})
-
-
-class Figcaption(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "figcaption"})
-
-
-class Canvas(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "canvas"})
+Image = simple_tag_class("img", self_closing=True)
+Video = simple_tag_class("video")
+Audio = simple_tag_class("audio")
+Source = simple_tag_class("source", self_closing=True)
+Picture = simple_tag_class("picture")
+Figure = simple_tag_class("figure")
+Figcaption = simple_tag_class("figcaption")
+Canvas = simple_tag_class("canvas")

--- a/src/ydnatl/tags/table.py
+++ b/src/ydnatl/tags/table.py
@@ -2,6 +2,15 @@ import csv
 import json
 
 from ydnatl.core.element import HTMLElement
+from ydnatl.tags.tag_factory import simple_tag_class
+
+
+TableFooter = simple_tag_class("tfoot")
+TableHeaderCell = simple_tag_class("th")
+TableHeader = simple_tag_class("thead")
+TableBody = simple_tag_class("tbody")
+TableDataCell = simple_tag_class("td")
+TableRow = simple_tag_class("tr")
 
 
 class Table(HTMLElement):
@@ -49,33 +58,3 @@ class Table(HTMLElement):
         except UnicodeDecodeError:
             raise ValueError(f"Encoding error: {encoding} is not suitable for the file")
         return table
-
-
-class TableFooter(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "tfoot"})
-
-
-class TableHeaderCell(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "th"})
-
-
-class TableHeader(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "thead"})
-
-
-class TableBody(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "tbody"})
-
-
-class TableDataCell(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "td"})
-
-
-class TableRow(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "tr"})

--- a/src/ydnatl/tags/tag_factory.py
+++ b/src/ydnatl/tags/tag_factory.py
@@ -1,0 +1,20 @@
+from ydnatl.core.element import HTMLElement
+
+
+# Factory function to create simple tag classes
+def simple_tag_class(tag, self_closing=False, extra_init=None):
+    class _Tag(HTMLElement):
+        def __init__(self, *args, **kwargs):
+            if extra_init:
+                extra_init(self, kwargs)
+            super().__init__(
+                *args,
+                **{
+                    **kwargs,
+                    "tag": tag,
+                    **({"self_closing": True} if self_closing else {}),
+                },
+            )
+
+    _Tag.__name__ = tag.capitalize() if tag.islower() else tag
+    return _Tag

--- a/src/ydnatl/tags/text.py
+++ b/src/ydnatl/tags/text.py
@@ -1,111 +1,25 @@
-from ydnatl.core.element import HTMLElement
+from ydnatl.tags.tag_factory import simple_tag_class
 
 
-class H1(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "h1"})
-
-
-class H2(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "h2"})
-
-
-class H3(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "h3"})
-
-
-class H4(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "h4"})
-
-
-class H5(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "h5"})
-
-
-class H6(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "h6"})
-
-
-class Paragraph(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "p"})
-
-
-class Blockquote(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "blockquote"})
-
-
-class Pre(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "pre"})
-
-
-class Quote(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "q"})
-
-
-class Cite(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "cite"})
-
-
-class Em(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "em"})
-
-
-class Italic(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "i"})
-
-
-class Span(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "span"})
-
-
-class Strong(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "strong"})
-
-
-class Abbr(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "abbr"})
-
-
-class Link(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "a"})
-
-
-class Small(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "small"})
-
-
-class Superscript(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "sup"})
-
-
-class Subscript(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "sub"})
-
-
-class Time(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "time"})
-
-
-class Code(HTMLElement):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **{**kwargs, "tag": "code"})
+H1 = simple_tag_class("h1")
+H2 = simple_tag_class("h2")
+H3 = simple_tag_class("h3")
+H4 = simple_tag_class("h4")
+H5 = simple_tag_class("h5")
+H6 = simple_tag_class("h6")
+Paragraph = simple_tag_class("p")
+Blockquote = simple_tag_class("blockquote")
+Pre = simple_tag_class("pre")
+Quote = simple_tag_class("q")
+Cite = simple_tag_class("cite")
+Em = simple_tag_class("em")
+Italic = simple_tag_class("i")
+Span = simple_tag_class("span")
+Strong = simple_tag_class("strong")
+Abbr = simple_tag_class("abbr")
+Link = simple_tag_class("a")
+Small = simple_tag_class("small")
+Superscript = simple_tag_class("sup")
+Subscript = simple_tag_class("sub")
+Time = simple_tag_class("time")
+Code = simple_tag_class("code")


### PR DESCRIPTION
**All tests passing**

Several changes discovered during initial review of this library, happy to remove or adjust anything as requested.

### Explicit Exports
- Top-level `src/ydnatl/__init__.py` previously utilized multiple `from .. import *` statements which left made it difficult to simply see a list of public available imports.
- `__all__` now clearly enumerates the publicly available API. 

### Centralized Tag Factory
-  Created a shared factory function `simple_tag_class` in `src/ydnatl/core/tag_factory.py` to replace widly re-used code throughout all tags. Functionality remains the same as before just with less duplication.

### `forms`
Consolidates Label creation with string tag support into a helper
Addresses `# TODO: Check if item is a valid field class`
