### PR TITLE
Fixed: flake8 issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/src/ydnatl/styles/stylesheet.py
+++ b/src/ydnatl/styles/stylesheet.py
@@ -1,8 +1,11 @@
 """StyleSheet class for managing CSS classes in YDNATL."""
 
-from typing import Dict, Optional, List
+from typing import Dict, Optional, List, TYPE_CHECKING
 
 from .style import CSSStyle
+
+if TYPE_CHECKING:
+    from .theme import Theme
 
 
 class StyleSheet:


### PR DESCRIPTION
This pull request makes two minor updates: it expands the supported Python versions in the CI test matrix and improves type hinting in the `StyleSheet` class for better static analysis.

* CI configuration:
  * [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L16-R16): Added Python 3.14 to the test matrix for broader compatibility.

* Codebase type safety:
  * [`src/ydnatl/styles/stylesheet.py`](diffhunk://#diff-6cc817936ced22a0fe12e6614167ec2949886e8c972ed656c32f578f61b20b27L3-R9): Added a conditional import for `Theme` using `TYPE_CHECKING` to improve type hinting without introducing runtime dependencies.